### PR TITLE
Update sidekiq_batch_adapter.rb

### DIFF
--- a/lib/importo/adapters/sidekiq_batch_adapter.rb
+++ b/lib/importo/adapters/sidekiq_batch_adapter.rb
@@ -8,7 +8,7 @@ if !defined?(Sidekiq::Batch)
   end
 end
 
-require "importo/import_job"
+require_relative "../../../app/jobs/importo/import_job"
 
 module Importo
   class SidekiqBatchAdapter


### PR DESCRIPTION
Use a relative path when including the `importo/importo_job` file.